### PR TITLE
Improve duet extraction, enable detection of rap notes

### DIFF
--- a/ss_extract.cc
+++ b/ss_extract.cc
@@ -282,8 +282,11 @@ struct Process {
 					for (int i = 0; i < NUM_SINGERS; ++i) {
 						trackElem[i] = dynamic_cast<xmlpp::Element*>(*it++);
 						xmlpp::Attribute *artistAttr = trackElem[i]->get_attribute("Artist");
-						if (!artistAttr)
-							throw std::runtime_error("Track without Artist");
+						if (!artistAttr) {
+							artistAttr = trackElem[i]->get_attribute("Name");
+							if (!artistAttr)
+								throw std::runtime_error("Track without Artist");
+						}
 						singerName[i] = artistAttr->get_value();
 						singerActive[i] = false;
 					}

--- a/ss_extract.cc
+++ b/ss_extract.cc
@@ -66,8 +66,13 @@ void parseNote(xmlpp::Node* node) {
 	}
 	unsigned note = boost::lexical_cast<unsigned>(elem.get_attribute("MidiNote")->get_value().c_str());
 	unsigned duration = boost::lexical_cast<unsigned>(elem.get_attribute("Duration")->get_value().c_str());
-	if (elem.get_attribute("FreeStyle")) type = 'F';
-	if (elem.get_attribute("Bonus")) type = '*';
+        bool rap = elem.get_attribute("Rap");
+        bool golden = elem.get_attribute("Bonus");
+        bool freestyle = elem.get_attribute("FreeStyle");
+        if (!rap && golden) type = '*';
+        else if (rap && !golden) type = 'R';
+        else if (rap && golden) type = 'G';
+        else if (freestyle) type = 'F';
 	if (note) {
 		if (sleepts > 0) notes << "- " << sleepts << '\n';
 		sleepts = 0;

--- a/ss_extract.cc
+++ b/ss_extract.cc
@@ -45,6 +45,7 @@ std::stringstream singerNotes[NUM_SINGERS];
 bool singerActive[NUM_SINGERS];
 int ts = 0;
 int sleepts = -1;
+int pitch_offset = 0;
 bool g_video = true;
 bool g_audio = true;
 bool g_mkvcompress = true;
@@ -76,7 +77,7 @@ void parseNote(xmlpp::Node* node) {
 	if (note) {
 		if (sleepts > 0) notes << "- " << sleepts << '\n';
 		sleepts = 0;
-		notes << type << ' ' << ts << ' ' << duration << ' ' << note << ' ' << lyric << '\n';
+		notes << type << ' ' << ts << ' ' << duration << ' ' << note - pitch_offset << ' ' << lyric << '\n';
 	}
 	ts += duration;
 
@@ -461,6 +462,7 @@ int main( int argc, char **argv) {
 	  ("audio", po::value<std::string>(&audio)->default_value("ogg"), "specify audio format (none, ogg, wav)")
 	  ("txt,t", "also convert XML to notes.txt (for UltraStar compatibility)")
 	  ("duet,d", "create single duet-mode txt file for duets")
+	  ("offset,o", "apply correct pitch offset")
 	  ;
 	// Process the first flagless option as dvd, the second as song
 	po::positional_options_description pos;
@@ -504,8 +506,10 @@ int main( int argc, char **argv) {
 		std::cerr << ">>> Using audio flag: \"" << audio << "\"" << std::endl;
 		g_createtxt = vm.count("txt") > 0 || vm.count("duet") > 0;
 		g_duet = vm.count("duet") > 0;
+		pitch_offset = (vm.count("offset") > 0 ? 60 : 0);
 		std::cerr << ">>> Convert XML to notes.txt: " << (g_createtxt?"yes":"no") << std::endl;
 		std::cerr << ">>> Create single duet-mode txt file for duets: " << (g_duet?"yes":"no") << std::endl;
+		std::cerr << ">>> Apply correct pitch offset: " << (pitch_offset?"yes":"no") << std::endl;
 	} catch (std::exception& e) {
 		std::cout << cmdline << std::endl;
 		std::cout << "ERROR: " << e.what() << std::endl;


### PR DESCRIPTION
The program previously wasn't able to extract duets to a single txt file directly and created two files instead. In addition, duets that have Duet="Yes" in the XML but all notes in a single track (distinguished by the Singer attribute in SENTENCE tags) were not detected. Both are fixed with this PR.

In addition, rap and golden rap notes are now detected (previously only freestyle).